### PR TITLE
Config Code

### DIFF
--- a/Socrata.py
+++ b/Socrata.py
@@ -119,7 +119,6 @@ class Dataset(SocrataBase):
             data['tags'] = tags
         
         response = self._request('/views.json', 'POST', data)
-        print response
         if response.has_key('error'):
             self.error = response['message']
             if response['code'] == 'authentication_required':

--- a/Socrata.py
+++ b/Socrata.py
@@ -47,7 +47,6 @@ class SocrataBase:
                      'X-App-Token': self.app_token},
             body=urlencode({'username': self.username, 'password': password}))
         cookies = re.search('(_blist_session_id=[^;]+)', response['set-cookie'])
-        print cookies
         self.cookie = cookies.group(0)
         # For multipart upload/streaming
         register_openers()

--- a/Socrata.py
+++ b/Socrata.py
@@ -47,6 +47,7 @@ class SocrataBase:
                      'X-App-Token': self.app_token},
             body=urlencode({'username': self.username, 'password': password}))
         cookies = re.search('(_blist_session_id=[^;]+)', response['set-cookie'])
+        print cookies
         self.cookie = cookies.group(0)
         # For multipart upload/streaming
         register_openers()
@@ -117,8 +118,9 @@ class Dataset(SocrataBase):
             data['flags'] = ['dataPublicRead']
         if tags.count > 0:
             data['tags'] = tags
-
+        
         response = self._request('/views.json', 'POST', data)
+        print response
         if response.has_key('error'):
             self.error = response['message']
             if response['code'] == 'authentication_required':
@@ -195,7 +197,7 @@ class Dataset(SocrataBase):
             return False
 
     def short_url(self):
-        return self.config.get('server', 'public_host') + "/d/" + str(self.id)
+        return self.config.get('server', 'host') + "/d/" + str(self.id)
 
 
 class DuplicateDatasetError(Exception):

--- a/socrata.cfg
+++ b/socrata.cfg
@@ -1,9 +1,9 @@
 [credentials]
-user:
-password:
-app_token:
+user: xxxx-xxxx (account 4x4 found in user profile)
+password: yourPassword
+app_token: xxxxxxxxxxxxxxxxxxxxx (application token created in your account profile)
 
 [server]
 host: http://opendata.socrata.com
-public_host: http://opendata.socrata.com
+api_host: http://opendata.socrata.com/api
 


### PR DESCRIPTION
Aiden,

In the code / cofig file there were: host, api_host, and public_host. I wasn't sure why there were so many hosts for python. I looked in the other language API code and didn't see anything like it. I removed / consolidated all references to public_host and made them api_host. I added values to the config to help explain what they are.

Anyway, it works now.

Thanks,
Todd
